### PR TITLE
Allowing touchio pins to work without needing import

### DIFF
--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -47,6 +47,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Debouncer.git"
 
 import time
 import digitalio
+import touchio
 from micropython import const
 
 _DEBOUNCED_STATE = const(0x01)
@@ -62,7 +63,7 @@ class Debouncer(object):
            :param int interval: bounce threshold in seconds (default is 0.010, i.e. 10 milliseconds)
         """
         self.state = 0x00
-        if isinstance(io_or_predicate, digitalio.DigitalInOut):
+        if isinstance(io_or_predicate, digitalio.DigitalInOut) or isinstance(io_or_predicate, touchio.TouchIn):
             self.function = lambda: io_or_predicate.value
         else:
             self.function = io_or_predicate

--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -46,7 +46,6 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Debouncer.git"
 
 import time
-import digitalio
 from micropython import const
 
 _DEBOUNCED_STATE = const(0x01)

--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -48,7 +48,6 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Debouncer.git"
 import time
 import digitalio
 from micropython import const
-import touchio
 
 _DEBOUNCED_STATE = const(0x01)
 _UNSTABLE_STATE = const(0x02)
@@ -63,7 +62,7 @@ class Debouncer(object):
            :param int interval: bounce threshold in seconds (default is 0.010, i.e. 10 milliseconds)
         """
         self.state = 0x00
-        if isinstance(io_or_predicate, (digitalio.DigitalInOut, touchio.TouchIn)):
+        if hasattr(io_or_predicate, 'value'):
             self.function = lambda: io_or_predicate.value
         else:
             self.function = io_or_predicate

--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -47,8 +47,8 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Debouncer.git"
 
 import time
 import digitalio
-import touchio
 from micropython import const
+import touchio
 
 _DEBOUNCED_STATE = const(0x01)
 _UNSTABLE_STATE = const(0x02)
@@ -63,7 +63,7 @@ class Debouncer(object):
            :param int interval: bounce threshold in seconds (default is 0.010, i.e. 10 milliseconds)
         """
         self.state = 0x00
-        if isinstance(io_or_predicate, digitalio.DigitalInOut) or isinstance(io_or_predicate, touchio.TouchIn):
+        if isinstance(io_or_predicate, (digitalio.DigitalInOut, touchio.TouchIn)):
             self.function = lambda: io_or_predicate.value
         else:
             self.function = io_or_predicate


### PR DESCRIPTION
This is forked from the PR #8 repo. It makes the change that jepler noted in that PR. Tested successfully with touchio pin and digitialio pin using CLUE. 