### PR TITLE
Run 'black --target-version=py35 .'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=[
-        "Adafruit-Blinka",
-    ],
+    install_requires=["Adafruit-Blinka",],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
I noticed that the build was throwing an error at the tip of the main development branch.