### PR TITLE
Update adafruit_debouncer.py

### DIFF
--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -62,12 +62,13 @@ _DEBOUNCED_STATE = const(0x01)
 _UNSTABLE_STATE = const(0x02)
 _CHANGED_STATE = const(0x04)
 
-# Find out whether the current CircuitPython supports time.monotonic_ns(),
+# Find out whether the current CircuitPython really supports time.monotonic_ns(),
 # which doesn't have the accuracy limitation.
-if hasattr(time, "monotonic_ns"):
+try:
+    time.monotonic_ns()
     TICKS_PER_SEC = 1_000_000_000
     MONOTONIC_TICKS = time.monotonic_ns
-else:
+except (ImportError, NotImplementedError):
     TICKS_PER_SEC = 1
     MONOTONIC_TICKS = time.monotonic
 

--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -68,7 +68,7 @@ try:
     time.monotonic_ns()
     TICKS_PER_SEC = 1_000_000_000
     MONOTONIC_TICKS = time.monotonic_ns
-except (ImportError, NotImplementedError):
+except (AttributeError, NotImplementedError):
     TICKS_PER_SEC = 1
     MONOTONIC_TICKS = time.monotonic
 


### PR DESCRIPTION
Testing if time.monotonic_ns() is really implemented.
Supposed to solve #22 
Works for me on PyPortal.

(not parsed with black or pylint, just copy and paste from my version in Mu)