### PR TITLE
Use adafruit ticks library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
+* `Adafruit Ticks <https://github.com/adafruit/Adafruit_CircuitPython_Ticks>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+adafruit-circuitpython-ticks

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     author_email="circuitpython@adafruit.com",
     install_requires=[
         "Adafruit-Blinka",
+        "adafruit-circuitpython-ticks",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
On boards without long int support, the debouncer library falls back to using `time.monotonic`, which loses accuracy over time as stated in the implementation notes.
This pull request fixes the issue by using adafruit ticks library.