### PR TITLE
Update Button class to match debouncer logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,18 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
 #
 # SPDX-License-Identifier: Unlicense
 
 *.mpy
+.idea
+__pycache__
+_build
+*.pyc
+.env
+.python-version
+build*/
+bundles
+*.DS_Store
+.eggs
+dist
+**/*.egg-info
+.vscode

--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -134,14 +134,16 @@ class Debouncer:
 
 class Button(Debouncer):
     """
-    Debounce counter. Counts multiple short presses (double click, triple click, etc.)
-    Reports long presses.
+    Debouncer for buttons. Reports ``pressed`` and ``released`` for the button state.
+    Counts multiple short presses, allowing to detect double clicks, triple clicks, etc.
+    Reports long presses separately. A long press can immediately follow multiple clicks,
+    in which case the long click will be reported in the same update as the short clicks.
 
     :param DigitalInOut/function pin: the DigitalIO or function to debounce.
     :param int short_duration_ms: the maximum length of a short press in milliseconds.
     :param int long_duration_ms: the minimum length of a long press in milliseconds.
     :param bool value_when_pressed: the value of the predicate when the button is
-    pressed. Defaults to False (pull up buttons are common).
+                                    pressed. Defaults to False (for pull up buttons).
     """
 
     def __init__(

--- a/examples/debouncer_multi.py
+++ b/examples/debouncer_multi.py
@@ -16,6 +16,5 @@ while True:
     switch.update()
     if switch.long_press:
         print("long")
-    count = switch.short_count
-    if count != 0:
-        print("count=", count)
+    if switch.short_count != 0:
+        print("count=", switch.short_count)

--- a/examples/debouncer_multi.py
+++ b/examples/debouncer_multi.py
@@ -15,6 +15,8 @@ switch = Button(pin)
 while True:
     switch.update()
     if switch.long_press:
-        print("long")
+        print("Long Press")
     if switch.short_count != 0:
-        print("count=", switch.short_count)
+        print("Short Press Count =", switch.short_count)
+    if switch.long_press and switch.short_count == 1:
+        print("That's a long double press !")


### PR DESCRIPTION
- `Button.short_count` and `Button.long_press` now return a consistent value that only changes when `Button.update()` is called, like `rose` and `fell` do. This is important for the logic of the debouncer to work, where the status of the button should be stable during a "frame".

- The `active_down` parameter is changed to `value_when_pressed`, a clearer name with the opposite value (also used in the keypad module). With `active_down`set to True, the active value when the button is pressed is False.

- Expose `Button.pressed` and `Button.released`, while rose/fell remain the lower level signal *direction of the edge*.

Note that `short_count` changes value after the `short_duration_ms` delay, so as to not report a double click as a simple click, so you would either use pressed/released if you don't look for double clicks or `short_count == 1` to detect a click, `2` for a double-click and more. Is that confusing ?

Maybe `value_when_pressed` and `pressed`/`released` could be moved into the Debouncer class.

- Improve the documentation of the Button class, with init parameters description.
- Update the gitignore to current cookiecutter while I'm here doing tests with sphinx (.env, _build, etc.)
