### PR TITLE
add force_set function

### DIFF
--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -106,6 +106,11 @@ class Debouncer:
                     )
                     self._state_changed_ticks = now_ticks
 
+    def force_set(self, state: bool)->None:
+        if self._get_state(_DEBOUNCED_STATE) != state:
+            self._set_state(_CHANGED_STATE)
+            self._toggle_state(_DEBOUNCED_STATE)
+
     @property
     def interval(self) -> float:
         """The debounce delay, in seconds"""

--- a/adafruit_debouncer.py
+++ b/adafruit_debouncer.py
@@ -107,6 +107,9 @@ class Debouncer:
                     self._state_changed_ticks = now_ticks
 
     def force_set(self, state: bool)->None:
+        """Manually set debounced value and trigger .rose or .fell
+        :param bool state: Value you want to manually set.
+        """
         if self._get_state(_DEBOUNCED_STATE) != state:
             self._set_state(_CHANGED_STATE)
             self._toggle_state(_DEBOUNCED_STATE)


### PR DESCRIPTION
Allows setting debounced state manually, bypassing the interval.

## Potential use case

A sensor requires 5s interval to filter out the noise. When `sensor.rose` triggers we somehow reset the machine(eg. we're trying fill up multiple bottles with water and once one bottle is full we move on to the next one). Normally `sensor.value` would go back to False after 5s but I want it False immediately so after resetting I call `sensor.force_set(False)`. If the sensor stays True after the reset, the 5s countdown will begin again and the machine will try to reset itself again.

## Example
```py
sensor = Debouncer(pin, interval=5)

while(True):
    sensor.update()

    if sensor.rose:
        reset() # do something that should reset the sensor
        sensor.force_set(False)
```